### PR TITLE
Fix Test output redirection to be fully POSIX compliant

### DIFF
--- a/cs3110-cli/command/test.ml
+++ b/cs3110-cli/command/test.ml
@@ -18,11 +18,11 @@ let test ?(quiet=false) ?(verbose=false) ?(compile=false) ?output ?dir (main_mod
     begin match output with
       | Some dest ->
         if quiet
-        then base_args @ ["2>& 1>/dev/null | grep '^File' > "; dest]
-        else base_args @ ["-show-counts"; "&>"; dest]
+        then base_args @ ["2>& 1>/dev/null | grep '^File' >"; dest]
+        else base_args @ ["-show-counts"; ">"; dest; "2>&1"]
       | None      ->
         if quiet
-        then base_args @ ["&>"; "/dev/null"]
+        then base_args @ [">/dev/null"; "2>&1"]
         else base_args @ ["-show-counts"]
     end
   in


### PR DESCRIPTION
Now it works with other shells that aren't bash.
The issue is that the &> syntax to redirect both
stderr and stdout at the same time is bash-specific.