### PR TITLE
Set utop and `cs3110 compile` to use the -safe-string flag

### DIFF
--- a/config/bashrc
+++ b/config/bashrc
@@ -1,1 +1,1 @@
-
+alias utop=utop -safe-string

--- a/cs3110-cli/command/compile.ml
+++ b/cs3110-cli/command/compile.ml
@@ -20,6 +20,7 @@ type options = Cli_config.compile_command_options
    Note that warnings 40-45 are for [ocamlopt] and not for [ocamlc].
    See more documentation here: http://caml.inria.fr/pub/docs/manual-ocaml/native.html *)
 let default_compiler_flags = [
+  "-safe-string";
   "-warn-error";
   "+a-4-33-34-40-41-42-43-44";
 ]


### PR DESCRIPTION
Ocaml 4.02 introduced the type `bytes` to enforce a separation between
mutable strings (the new `bytes` type) and immutable strings (the`string`
type). However, for backwards compatibility purposes the -unsafe-string
flag is the current default, meaning the two are interchangeable: strings
become a mutable data structure (not what we generally want in 3110), and
utop says strings are of type `bytes` which is confusing.

This change simply adds the -safe-string flag (which the OCaml
documentation recommends all new code have) to invocations of `utop` and
`cs3110 compile`.