### PR TITLE
Make `cs3110 compile` learn the `-use-menhir` flag

### DIFF
--- a/cs3110-cli/command/compile.ml
+++ b/cs3110-cli/command/compile.ml
@@ -65,17 +65,19 @@ let format_libraries (libs : StringSet.t) : string list =
     | xs -> ["-libs"; "assertions," ^ (String.concat ~sep:"," xs)]
   end
 
-(** [format_ocamlbuild_flags ?mktop pkgs] Prepare the set of opam packages [pkgs]
+(** [format_ocamlbuild_flags ?mktop ?menhir pkgs] Prepare the set of opam packages [pkgs]
     to be passed in to the ocamlbuild command line. Output differs if we are
     making an executable toplevel i.e. when [mktop] is true. *)
-let format_ocamlbuild_flags ?(mktop=false) ?(thread=false) (pkgs : StringSet.t) : string list =
+let format_ocamlbuild_flags ?(mktop=false) ?(menhir=false) ?(thread=false) (pkgs : StringSet.t) : string list =
+  let oflags = if menhir then "-use-menhir"::default_ocamlbuild_flags
+    else default_ocamlbuild_flags in
   if mktop then
     let pkgs = begin match StringSet.to_list pkgs with
                  | []  -> []
                  | [x] -> ["-pkg"; x]
                  | xs  -> ["-pkgs"; (String.concat ~sep:"," xs)]
                end
-    in default_ocamlbuild_flags @ pkgs
+    in oflags @ pkgs
   else
     let pkgs_str =
       begin match StringSet.to_list pkgs with
@@ -85,7 +87,7 @@ let format_ocamlbuild_flags ?(mktop=false) ?(thread=false) (pkgs : StringSet.t) 
            if thread then "thread, " ^ pkgs else pkgs
       end
     in
-    default_ocamlbuild_flags @ [
+    oflags @ [
       "-tag-line";
       "<**/*.ml{,i}> : syntax(camlp4o), " ^ pkgs_str;
       "-tag-line";
@@ -124,7 +126,7 @@ let get_target ?(mktop=false) (main : string) : string =
 
 (** [compile ?q ?v ?m ?d ?o main] compile [main] into a bytecode executable.
     Relies on ocamlbuild. *)
-let compile ?(quiet=false) ?(verbose=false) ?(mktop=false) ?dir ?opts (main_module : string) : int =
+let compile ?(quiet=false) ?(verbose=false) ?(mktop=false) ?(menhir=false) ?dir ?opts (main_module : string) : int =
   let opts      = (begin match opts with
                      | Some o -> o
                      | None   -> (Cli_config.init ()).compile
@@ -143,7 +145,7 @@ let compile ?(quiet=false) ?(verbose=false) ?(mktop=false) ?dir ?opts (main_modu
   let cflags    = format_compiler_flags default_compiler_flags in (* 2014-07-30: ignores the config's compiler flags *)
   let ()        = if verbose then Format.printf "[compile] Compiler flags are [%s]\n"       (String.concat ~sep:"; " cflags) in
   let run_quiet = if quiet then ["-quiet"] else [] in
-  let oflags    = format_ocamlbuild_flags ~mktop:mktop ~thread:opts.thread opts.opam_packages in
+  let oflags    = format_ocamlbuild_flags ~mktop:mktop ~menhir:menhir ~thread:opts.thread opts.opam_packages in
   let ()        = if verbose then Format.printf "[compile] ocamlbuild flags are [%s]\n"     (String.concat ~sep:"; " oflags) in
   let command   = deps @ libs @ cflags @ run_quiet @ oflags @ [target] in
   (* 2014-07-23: Need to flush before ocamlbuild prints. *)
@@ -174,13 +176,14 @@ let command =
       +> flag ~aliases:["-q"]             "-quiet"    no_arg            ~doc:" Compile quietly."
       +> flag ~aliases:["-v"]             "-verbose"  no_arg            ~doc:" Print debugging information (about compiler options, etc.)."
       +> flag ~aliases:["-top"; "-mktop"] "-toplevel" no_arg            ~doc:" Create a custom toplevel (.top file) inside the '_build' directory instead of an executable."
+      +> flag ~aliases:["-menhir"]        "-use-menhir" no_arg          ~doc:" Compile with the ocamlbuild flag -use-menhir."
       +> flag ~aliases:["-t"]             "-thread"   no_arg            ~doc:" Compile with threading libraries."
       +> flag ~aliases:["-I"]             "-include"  (listed file)     ~doc:"DIR Search the directory DIR recursively for dependencies."
       +> flag ~aliases:["-p"; "-pkg"]     "-package"  (listed string)   ~doc:"PKG Include the OPAM package PKG."
       +> flag ~aliases:["-l"; "-lib"]     "-library"  (listed string)   ~doc:"LIB Include the OCaml library LIB."
       +> anon ("target" %: file)
     )
-    (fun q v mktop thread includes pkgs libs target () ->
+    (fun q v mktop menhir thread includes pkgs libs target () ->
       let ()   = assert_ocamlbuild_friendly_filepath target in
       let cfg  = Cli_config.init () in
       let opts = ({
@@ -198,5 +201,5 @@ let command =
                               end;
         thread              = thread || cfg.compile.thread;
       } : options) in
-      check_code (compile ~quiet:q ~verbose:v ~mktop:mktop ~opts:opts target)
+      check_code (compile ~quiet:q ~verbose:v ~mktop:mktop ~menhir:menhir ~opts:opts target)
     )

--- a/cs3110-cli/command/compile.mli
+++ b/cs3110-cli/command/compile.mli
@@ -1,2 +1,2 @@
-val compile : ?quiet:bool -> ?verbose:bool -> ?mktop:bool -> ?dir:string -> ?opts:Cli_config.compile_command_options -> string -> int
+val compile : ?quiet:bool -> ?verbose:bool -> ?mktop:bool -> ?menhir:bool -> ?dir:string -> ?opts:Cli_config.compile_command_options -> string -> int
 val command : Core.Std.Command.t


### PR DESCRIPTION
If `-use-menhir` is passed to cs3110 compile, `-use-menhir` will be set as a flag for ocamlbuild.